### PR TITLE
Implement save/load system

### DIFF
--- a/game/project.godot
+++ b/game/project.godot
@@ -112,6 +112,16 @@ hotbar_9={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":57,"key_label":0,"unicode":57,"location":0,"echo":false,"script":null)
 ]
 }
+save_game={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194336,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+load_game={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194340,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 
 [physics]
 

--- a/game/scripts/components/inventory.gd
+++ b/game/scripts/components/inventory.gd
@@ -170,6 +170,30 @@ func swap_slots(index_a: int, index_b: int) -> void:
 	inventory_updated.emit()
 
 
+## Serialize inventory to a sparse array of non-empty slots.
+## Format: [{"slot": index, "item": type, "count": n}, ...]
+func serialize() -> Array:
+	var result: Array = []
+	for i in range(_slots.size()):
+		var slot := _slots[i]
+		if slot.item != NONE and slot.count > 0:
+			result.append({"slot": i, "item": slot.item, "count": slot.count})
+	return result
+
+
+## Deserialize inventory from a sparse array of slot dictionaries.
+## Clears all slots first, then restores only the saved non-empty ones.
+func deserialize(data: Array) -> void:
+	_initialize_slots()
+	for entry in data:
+		if entry is Dictionary and entry.has("slot") and entry.has("item") and entry.has("count"):
+			var idx: int = int(entry["slot"])
+			if idx >= 0 and idx < _slots.size():
+				_slots[idx].item = int(entry["item"])
+				_slots[idx].count = int(entry["count"])
+	inventory_updated.emit()
+
+
 ## Move items from one slot to another. If the target slot has the same item type,
 ## items are stacked. If different types, the slots are swapped.
 ## If shift is true, moves the entire stack to the target slot.

--- a/game/scripts/entities/miner.gd
+++ b/game/scripts/entities/miner.gd
@@ -169,3 +169,25 @@ func _complete_mining(block_type: int) -> void:
 ## Returns the Inventory component
 func get_inventory() -> Inventory:
 	return get_component("Inventory") as Inventory
+
+
+## Serialize miner state to a dictionary
+func serialize() -> Dictionary:
+	return {
+		"type": "Miner",
+		"position": {"x": position.x, "y": position.y},
+		"direction": {"x": direction.x, "y": direction.y},
+		"state": _state,
+		"inventory": get_inventory().serialize(),
+	}
+
+
+## Restore miner state from a dictionary.
+## Call after setup() so position/direction are overwritten with saved values.
+func deserialize(data: Dictionary) -> void:
+	var state_val: int = int(data.get("state", State.IDLE))
+	_state = state_val as State
+
+	var inv_data: Array = data.get("inventory", [])
+	if inv_data.size() > 0:
+		get_inventory().deserialize(inv_data)

--- a/game/scripts/main.gd
+++ b/game/scripts/main.gd
@@ -3,9 +3,11 @@ extends Node2D
 ## Main game scene
 ##
 ## Wires together world, player, controllers, and UI.
+## Manages save/load lifecycle via SaveManager.
 
 var tile_world: TileWorld
 var inventory: Inventory
+var save_manager: SaveManager
 
 @onready var world_renderer: WorldRenderer = $WorldRenderer
 @onready var player: PlayerController = $Player
@@ -23,11 +25,16 @@ const PLAYER_SPAWN_X = 0
 
 
 func _ready() -> void:
-	# Create core systems
-	tile_world = TileWorld.new(WORLD_SEED)
-	inventory = Inventory.new()
-	# Add starting items
-	inventory.add_item(ItemData.ItemType.MINER, 1)
+	# Create save manager
+	save_manager = SaveManager.new()
+	save_manager.name = "SaveManager"
+	add_child(save_manager)
+
+	# Try loading a save, otherwise start fresh
+	if save_manager.has_save():
+		_load_game()
+	else:
+		_new_game()
 
 	# Setup world renderer
 	world_renderer.set_tile_world(tile_world)
@@ -43,19 +50,111 @@ func _ready() -> void:
 
 	# Setup input manager
 	input_manager.setup(player, mining_controller, placement_controller, hotbar_ui, inventory_ui, miner_inventory_ui)
-
-	# Spawn player above terrain
-	_spawn_player_above_terrain()
+	input_manager.save_requested.connect(_on_save_requested)
+	input_manager.load_requested.connect(_on_load_requested)
 
 	# Setup background parallax (after spawn so camera position is set)
 	bgparallax_controller.setup(player.get_node("Camera2D"))
 
-	# # Debug logging
-	# var cam = player.get_node("Camera2D") as Camera2D
-	# var vp = get_viewport().get_visible_rect().size
-	# print("[Main] player.position=%s  tile=%s" % [player.position, WorldUtils.world_to_tile(player.position)])
-	# print("[Main] camera.zoom=%s  viewport=%s  visible_world=%s" % [cam.zoom, vp, vp / cam.zoom])
-	# print("[Main] surface_y=%d  surface_world_y=%d" % [_find_surface_y(PLAYER_SPAWN_X), -_find_surface_y(PLAYER_SPAWN_X) * WorldUtils.TILE_SIZE])
+	# Configure save manager references and start auto-save
+	_update_save_manager_refs()
+	save_manager.set_auto_save(true)
+
+
+## Start a fresh game with default state
+func _new_game() -> void:
+	tile_world = TileWorld.new(WORLD_SEED)
+	inventory = Inventory.new()
+	inventory.add_item(ItemData.ItemType.MINER, 1)
+	_spawn_player_above_terrain()
+
+
+## Load game state from save file
+func _load_game() -> void:
+	var data := save_manager.load_game()
+	if data.is_empty():
+		# Fallback to new game if load fails
+		_new_game()
+		return
+
+	# Restore world
+	var world_data: Dictionary = data.get("world", {})
+	tile_world = TileWorld.deserialize(world_data)
+
+	# Restore player
+	var player_data: Dictionary = data.get("player", {})
+	if player_data.has("position"):
+		player.deserialize(player_data)
+	else:
+		_spawn_player_above_terrain()
+
+	# Restore player inventory
+	inventory = Inventory.new()
+	var inv_slots: Array = player_data.get("inventory", [])
+	inventory.deserialize(inv_slots)
+
+	# Restore entities (deferred to ensure scene tree is ready)
+	var entities_data: Array = data.get("entities", [])
+	if entities_data.size() > 0:
+		EntitySaver.deserialize_all(entities_data, self, tile_world)
+
+
+func _on_save_requested() -> void:
+	_update_save_manager_refs()
+	if save_manager.save_game():
+		print("[Main] Game saved successfully")
+	else:
+		print("[Main] Failed to save game")
+
+
+func _on_load_requested() -> void:
+	# Remove existing miners before loading
+	_remove_all_miners()
+
+	var data := save_manager.load_game()
+	if data.is_empty():
+		print("[Main] No save file to load")
+		return
+
+	# Restore world
+	var world_data: Dictionary = data.get("world", {})
+	tile_world = TileWorld.deserialize(world_data)
+
+	# Reconnect world to renderer and controllers
+	world_renderer.set_tile_world(tile_world)
+	mining_controller.setup(tile_world, inventory)
+	placement_controller.setup(tile_world, inventory)
+
+	# Restore player
+	var player_data: Dictionary = data.get("player", {})
+	if player_data.has("position"):
+		player.deserialize(player_data)
+
+	# Restore player inventory
+	var inv_slots: Array = player_data.get("inventory", [])
+	inventory.deserialize(inv_slots)
+
+	# Restore entities
+	var entities_data: Array = data.get("entities", [])
+	if entities_data.size() > 0:
+		EntitySaver.deserialize_all(entities_data, self, tile_world)
+
+	_update_save_manager_refs()
+	print("[Main] Game loaded successfully")
+
+
+func _update_save_manager_refs() -> void:
+	save_manager.tile_world = tile_world
+	save_manager.player_inventory = inventory
+	save_manager.player_node = player
+	save_manager.scene_tree = get_tree()
+	save_manager.entity_parent = self
+
+
+func _remove_all_miners() -> void:
+	for miner in get_tree().get_nodes_in_group("miners"):
+		if is_instance_valid(miner):
+			miner.queue_free()
 
 
 func _spawn_player_above_terrain() -> void:

--- a/game/scripts/player/input_manager.gd
+++ b/game/scripts/player/input_manager.gd
@@ -9,6 +9,9 @@ var inventory_ui: InventoryUI
 var miner_inventory_ui: InventoryUI
 var active_miner_entity: Miner = null
 
+signal save_requested
+signal load_requested
+
 const MAX_INTERACTION_DISTANCE = 64.0
 
 
@@ -34,6 +37,7 @@ func _process(_delta: float) -> void:
 	_handle_actions()
 	_handle_hotbar_selection()
 	_handle_ui()
+	_handle_save_load()
 	_check_miner_distance()
 
 
@@ -151,3 +155,10 @@ func _handle_hotbar_selection() -> void:
 				hotbar_ui.select_slot(i)
 			if placement_controller:
 				placement_controller.set_selected_slot(i)
+
+
+func _handle_save_load() -> void:
+	if Input.is_action_just_pressed("save_game"):
+		save_requested.emit()
+	if Input.is_action_just_pressed("load_game"):
+		load_requested.emit()

--- a/game/scripts/player/player_controller.gd
+++ b/game/scripts/player/player_controller.gd
@@ -96,3 +96,17 @@ func stop() -> void:
 	move_direction = 0.0
 	wants_jump = false
 	wants_walk = false
+
+
+## Serialize player state to a dictionary
+func serialize() -> Dictionary:
+	return {
+		"position": {"x": position.x, "y": position.y},
+	}
+
+
+## Restore player state from a dictionary
+func deserialize(data: Dictionary) -> void:
+	var pos_data: Dictionary = data.get("position", {})
+	if pos_data.has("x") and pos_data.has("y"):
+		position = Vector2(float(pos_data["x"]), float(pos_data["y"]))

--- a/game/scripts/rendering/world_renderer.gd
+++ b/game/scripts/rendering/world_renderer.gd
@@ -41,6 +41,7 @@ func set_tile_world(world: TileWorld) -> void:
 		tile_world.block_changed.disconnect(_on_block_changed)
 
 	tile_world = world
+	clear()
 	if tile_world != null:
 		tile_world.block_changed.connect(_on_block_changed)
 

--- a/game/scripts/save/entity_saver.gd
+++ b/game/scripts/save/entity_saver.gd
@@ -1,0 +1,57 @@
+class_name EntitySaver
+extends RefCounted
+## Collects and dispatches entity serialization/deserialization
+##
+## Iterates entity groups in the scene tree and delegates to each
+## entity's own serialize()/deserialize() methods.
+## Handles scene instantiation on load.
+
+
+## Serialize all entities in the scene tree
+static func serialize_all(tree: SceneTree) -> Array:
+	var entities: Array = []
+	for miner in tree.get_nodes_in_group("miners"):
+		if miner is Miner and is_instance_valid(miner):
+			entities.append(miner.serialize())
+	return entities
+
+
+## Deserialize all entities from saved data and add them to the scene.
+## Returns the array of instantiated entities.
+static func deserialize_all(entities_data: Array, parent: Node, tile_world: TileWorld) -> Array:
+	var result: Array = []
+	for entity_data in entities_data:
+		var type_name: String = entity_data.get("type", "")
+		match type_name:
+			"Miner":
+				var miner := _instantiate_miner(entity_data, parent, tile_world)
+				if miner:
+					result.append(miner)
+	return result
+
+
+## Instantiate a miner from saved data, add to scene, and restore state.
+static func _instantiate_miner(data: Dictionary, parent: Node, tile_world: TileWorld) -> Miner:
+	var miner_scene := load("res://scenes/entities/miner.tscn")
+	if miner_scene == null:
+		return null
+
+	var miner: Miner = miner_scene.instantiate()
+	parent.add_child(miner)
+
+	# Extract position and direction for setup()
+	var pos_data: Dictionary = data.get("position", {})
+	var dir_data: Dictionary = data.get("direction", {})
+	var spawn_pos := Vector2(
+		float(pos_data.get("x", 0.0)),
+		float(pos_data.get("y", 0.0))
+	)
+	var direction := Vector2i(
+		int(dir_data.get("x", 1)),
+		int(dir_data.get("y", 0))
+	)
+
+	miner.setup(tile_world, spawn_pos, direction)
+	miner.deserialize(data)
+
+	return miner

--- a/game/scripts/save/entity_saver.gd.uid
+++ b/game/scripts/save/entity_saver.gd.uid
@@ -1,0 +1,1 @@
+uid://c3sbws0ksf6as

--- a/game/scripts/save/save_manager.gd
+++ b/game/scripts/save/save_manager.gd
@@ -1,0 +1,179 @@
+class_name SaveManager
+extends Node
+## Orchestrates save/load operations for the entire game state
+##
+## Coordinates entity owners to produce a single JSON save file.
+## Each component serializes itself; SaveManager just collects and writes.
+## Supports manual save/load and periodic auto-save.
+
+const SAVE_VERSION := "0.1.0"
+const SAVE_DIR := "user://saves/"
+const DEFAULT_SAVE_FILE := "save.json"
+const AUTO_SAVE_INTERVAL := 300.0  # seconds (5 minutes)
+
+signal game_saved(path: String)
+signal game_loaded(path: String)
+signal save_error(message: String)
+
+var _auto_save_timer: Timer
+var _auto_save_enabled: bool = false
+
+## References set by Main before use
+var tile_world: TileWorld
+var player_inventory: Inventory
+var player_node: PlayerController
+var scene_tree: SceneTree
+var entity_parent: Node
+
+
+func _ready() -> void:
+	_ensure_save_dir()
+	_setup_auto_save_timer()
+
+
+# =============================================================================
+# Public API
+# =============================================================================
+
+## Save the current game state to the given filename.
+## Returns true on success.
+func save_game(filename: String = DEFAULT_SAVE_FILE) -> bool:
+	if tile_world == null or player_inventory == null or player_node == null:
+		save_error.emit("Cannot save: missing game references")
+		return false
+
+	var data := _build_save_data()
+	var json_string := JSON.stringify(data, "\t")
+
+	var path := SAVE_DIR + filename
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	if file == null:
+		var err_msg := "Failed to open save file: %s (error %d)" % [path, FileAccess.get_open_error()]
+		save_error.emit(err_msg)
+		return false
+
+	file.store_string(json_string)
+	file.close()
+
+	game_saved.emit(path)
+	return true
+
+
+## Load game state from the given filename.
+## Returns the parsed save dictionary, or an empty dictionary on failure.
+## The caller (Main) is responsible for applying the loaded state.
+func load_game(filename: String = DEFAULT_SAVE_FILE) -> Dictionary:
+	var path := SAVE_DIR + filename
+
+	if not FileAccess.file_exists(path):
+		save_error.emit("Save file not found: %s" % path)
+		return {}
+
+	var file := FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		save_error.emit("Failed to open save file: %s" % path)
+		return {}
+
+	var json_string := file.get_as_text()
+	file.close()
+
+	var json := JSON.new()
+	var parse_result := json.parse(json_string)
+	if parse_result != OK:
+		save_error.emit("Failed to parse save file: %s" % json.get_error_message())
+		return {}
+
+	var data: Dictionary = json.data
+	if not _validate_save_data(data):
+		save_error.emit("Invalid save data format")
+		return {}
+
+	game_loaded.emit(path)
+	return data
+
+
+## Check if a save file exists
+func has_save(filename: String = DEFAULT_SAVE_FILE) -> bool:
+	return FileAccess.file_exists(SAVE_DIR + filename)
+
+
+## Enable or disable auto-save
+func set_auto_save(enabled: bool) -> void:
+	_auto_save_enabled = enabled
+	if enabled:
+		_auto_save_timer.start(AUTO_SAVE_INTERVAL)
+	else:
+		_auto_save_timer.stop()
+
+
+## Delete a save file. Returns true on success.
+func delete_save(filename: String = DEFAULT_SAVE_FILE) -> bool:
+	var path := SAVE_DIR + filename
+	if FileAccess.file_exists(path):
+		var err := DirAccess.remove_absolute(path)
+		return err == OK
+	return false
+
+
+# =============================================================================
+# Save Data Construction
+# =============================================================================
+
+func _build_save_data() -> Dictionary:
+	var player_data := player_node.serialize()
+	player_data["inventory"] = player_inventory.serialize()
+
+	var data := {
+		"version": SAVE_VERSION,
+		"timestamp": Time.get_unix_time_from_system(),
+		"world": tile_world.serialize(),
+		"player": player_data,
+		"entities": _serialize_entities(),
+	}
+	return data
+
+
+func _serialize_entities() -> Array:
+	if scene_tree == null:
+		return []
+	return EntitySaver.serialize_all(scene_tree)
+
+
+# =============================================================================
+# Validation
+# =============================================================================
+
+func _validate_save_data(data: Dictionary) -> bool:
+	if not data.has("version"):
+		return false
+	if not data.has("world"):
+		return false
+	if not data.has("player"):
+		return false
+	return true
+
+
+# =============================================================================
+# Auto-save
+# =============================================================================
+
+func _setup_auto_save_timer() -> void:
+	_auto_save_timer = Timer.new()
+	_auto_save_timer.one_shot = false
+	_auto_save_timer.wait_time = AUTO_SAVE_INTERVAL
+	_auto_save_timer.timeout.connect(_on_auto_save)
+	add_child(_auto_save_timer)
+
+
+func _on_auto_save() -> void:
+	if _auto_save_enabled:
+		save_game("autosave.json")
+
+
+# =============================================================================
+# Utilities
+# =============================================================================
+
+func _ensure_save_dir() -> void:
+	if not DirAccess.dir_exists_absolute(SAVE_DIR):
+		DirAccess.make_dir_recursive_absolute(SAVE_DIR)

--- a/game/scripts/save/save_manager.gd.uid
+++ b/game/scripts/save/save_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://ca7ixsg2istut

--- a/game/scripts/world/tile_world.gd
+++ b/game/scripts/world/tile_world.gd
@@ -5,10 +5,12 @@ extends RefCounted
 ## Stores tiles in a Dictionary keyed by Vector2i coordinates.
 ## Generates terrain on demand using TerrainGenerator when a tile is first accessed.
 ## Emits signals when blocks are changed.
+## Tracks player-modified tiles separately for efficient serialization.
 
 var world_seed: int = 0
 var terrain_generator: TerrainGenerator
 var _tiles: Dictionary = {}  # Vector2i -> int (BlockType)
+var _modified_tiles: Dictionary = {}  # Vector2i -> int (only player-changed tiles)
 
 signal block_changed(position: Vector2i, old_type: int, new_type: int)
 
@@ -32,8 +34,53 @@ func set_block(x: int, y: int, block_type: int) -> void:
 	var pos := Vector2i(x, y)
 	var old_type := get_block(x, y)
 	_tiles[pos] = block_type
+	_modified_tiles[pos] = block_type
 	block_changed.emit(pos, old_type, block_type)
 
 
 func is_solid(x: int, y: int) -> bool:
 	return BlockData.is_solid(get_block(x, y))
+
+
+## Returns a dictionary of all player-modified tiles for serialization.
+## Format: { "x,y": block_type_int, ... }
+func get_modified_tiles() -> Dictionary:
+	var result := {}
+	for pos in _modified_tiles:
+		var key := "%d,%d" % [pos.x, pos.y]
+		result[key] = _modified_tiles[pos]
+	return result
+
+
+## Restores modified tiles from a serialized dictionary.
+## Overwrites generated terrain with saved values.
+func load_modified_tiles(data: Dictionary) -> void:
+	for key in data:
+		var parts := (key as String).split(",")
+		if parts.size() != 2:
+			continue
+		var x := int(parts[0])
+		var y := int(parts[1])
+		var block_type: int = int(data[key])
+		var pos := Vector2i(x, y)
+		_tiles[pos] = block_type
+		_modified_tiles[pos] = block_type
+
+
+## Serialize world state to a dictionary.
+## Only includes the seed and player-modified tiles.
+func serialize() -> Dictionary:
+	return {
+		"seed": world_seed,
+		"modified_tiles": get_modified_tiles(),
+	}
+
+
+## Create a new TileWorld from serialized data.
+## Restores seed and modified tiles; unmodified terrain regenerates on demand.
+static func deserialize(data: Dictionary) -> TileWorld:
+	var seed_value: int = int(data.get("seed", 0))
+	var world := TileWorld.new(seed_value)
+	var modified: Dictionary = data.get("modified_tiles", {})
+	world.load_modified_tiles(modified)
+	return world

--- a/game/tests/unit/test_save_system.gd
+++ b/game/tests/unit/test_save_system.gd
@@ -1,0 +1,737 @@
+extends GutTest
+## Unit tests for the Save/Load system
+##
+## Tests TileWorld, Miner, Inventory, PlayerController serialization,
+## EntitySaver dispatching, and SaveManager orchestration.
+
+
+## Create a PlayerController with the required child nodes for testing.
+## PlayerController._ready() expects a "PlayerSpriteAnimation2D" child.
+func _create_test_player() -> PlayerController:
+	var player = PlayerController.new()
+	var sprite = AnimatedSprite2D.new()
+	sprite.name = "PlayerSpriteAnimation2D"
+	var frames = SpriteFrames.new()
+	frames.add_animation("jump")
+	frames.add_animation("run")
+	frames.add_animation("walk")
+	frames.add_animation("idle")
+	sprite.sprite_frames = frames
+	player.add_child(sprite)
+	return player
+
+
+# =============================================================================
+# TileWorld Serialization Tests
+# =============================================================================
+
+func test_tile_world_tracks_modified_tiles():
+	var world = TileWorld.new(42)
+	# get_block only generates, doesn't mark as modified
+	var _block = world.get_block(10, 20)
+
+	var modified = world.get_modified_tiles()
+	assert_eq(modified.size(), 0, "Generated tiles should not be tracked as modified")
+
+
+func test_tile_world_tracks_set_block_as_modified():
+	var world = TileWorld.new(42)
+	world.set_block(5, 10, BlockData.BlockType.STONE)
+
+	var modified = world.get_modified_tiles()
+	assert_eq(modified.size(), 1, "set_block should track tile as modified")
+	assert_true(modified.has("5,10"), "Modified tiles should use 'x,y' key format")
+	assert_eq(modified["5,10"], BlockData.BlockType.STONE, "Modified tile value should match")
+
+
+func test_tile_world_tracks_multiple_modifications():
+	var world = TileWorld.new(42)
+	world.set_block(0, 0, BlockData.BlockType.DIRT)
+	world.set_block(1, 1, BlockData.BlockType.COBBLESTONE)
+	world.set_block(-5, 3, BlockData.BlockType.AIR)
+
+	var modified = world.get_modified_tiles()
+	assert_eq(modified.size(), 3, "Should track all modified tiles")
+
+
+func test_tile_world_overwrite_tracks_latest_value():
+	var world = TileWorld.new(42)
+	world.set_block(5, 5, BlockData.BlockType.STONE)
+	world.set_block(5, 5, BlockData.BlockType.AIR)
+
+	var modified = world.get_modified_tiles()
+	assert_eq(modified.size(), 1, "Overwritten tile should still be one entry")
+	assert_eq(modified["5,5"], BlockData.BlockType.AIR, "Should track latest value")
+
+
+func test_tile_world_load_modified_tiles():
+	var world = TileWorld.new(42)
+	var data = {"10,20": BlockData.BlockType.DIAMOND_ORE, "-3,5": BlockData.BlockType.GOLD_ORE}
+
+	world.load_modified_tiles(data)
+
+	assert_eq(world.get_block(10, 20), BlockData.BlockType.DIAMOND_ORE, "Loaded tile should override generation")
+	assert_eq(world.get_block(-3, 5), BlockData.BlockType.GOLD_ORE, "Loaded tile should override generation")
+
+
+func test_tile_world_load_modified_tiles_roundtrip():
+	var world1 = TileWorld.new(99)
+	world1.set_block(0, 0, BlockData.BlockType.PLANKS)
+	world1.set_block(100, -50, BlockData.BlockType.IRON_ORE)
+
+	var saved = world1.get_modified_tiles()
+
+	var world2 = TileWorld.new(99)
+	world2.load_modified_tiles(saved)
+
+	assert_eq(world2.get_block(0, 0), BlockData.BlockType.PLANKS, "Roundtrip should preserve block")
+	assert_eq(world2.get_block(100, -50), BlockData.BlockType.IRON_ORE, "Roundtrip should preserve block")
+
+
+func test_tile_world_load_ignores_malformed_keys():
+	var world = TileWorld.new(42)
+	var data = {"bad_key": 3, "10,20,30": 5, "": 1}
+
+	# Should not crash
+	world.load_modified_tiles(data)
+
+	# Valid key should not be loaded since all keys are malformed
+	var modified = world.get_modified_tiles()
+	assert_eq(modified.size(), 0, "Malformed keys should be ignored")
+
+
+func test_tile_world_serialize_includes_seed():
+	var world = TileWorld.new(12345)
+	var data = world.serialize()
+
+	assert_true(data.has("seed"), "Serialized data should include seed")
+	assert_eq(data["seed"], 12345, "Seed should match world seed")
+
+
+func test_tile_world_serialize_includes_modified_tiles():
+	var world = TileWorld.new(42)
+	world.set_block(5, 10, BlockData.BlockType.STONE)
+
+	var data = world.serialize()
+
+	assert_true(data.has("modified_tiles"), "Serialized data should include modified_tiles")
+	assert_eq(data["modified_tiles"].size(), 1, "Should have one modified tile")
+
+
+func test_tile_world_serialize_empty_world():
+	var world = TileWorld.new(42)
+	var data = world.serialize()
+
+	assert_eq(data["modified_tiles"].size(), 0, "Unmodified world should have no modified tiles")
+
+
+func test_tile_world_deserialize_restores_seed():
+	var world = TileWorld.new(999)
+	world.set_block(0, 0, BlockData.BlockType.PLANKS)
+
+	var data = world.serialize()
+	var restored = TileWorld.deserialize(data)
+
+	assert_eq(restored.world_seed, 999, "Deserialized world should have correct seed")
+
+
+func test_tile_world_deserialize_restores_modified_tiles():
+	var world = TileWorld.new(42)
+	world.set_block(10, 20, BlockData.BlockType.DIAMOND_ORE)
+	world.set_block(-5, 3, BlockData.BlockType.AIR)
+
+	var data = world.serialize()
+	var restored = TileWorld.deserialize(data)
+
+	assert_eq(restored.get_block(10, 20), BlockData.BlockType.DIAMOND_ORE, "Should restore modified block")
+	assert_eq(restored.get_block(-5, 3), BlockData.BlockType.AIR, "Should restore modified block")
+
+
+func test_tile_world_deserialize_regenerates_unmodified():
+	var world = TileWorld.new(42)
+	# Only modify one block; others should regenerate
+	world.set_block(0, 0, BlockData.BlockType.PLANKS)
+
+	var data = world.serialize()
+	var restored = TileWorld.deserialize(data)
+
+	# Unmodified block should match procedural generation
+	var expected = TileWorld.new(42)
+	assert_eq(restored.get_block(100, 30), expected.get_block(100, 30),
+		"Unmodified blocks should regenerate from seed")
+
+
+func test_tile_world_roundtrip_preserves_generation():
+	var original = TileWorld.new(42)
+	var gen_block = original.get_block(50, 25)
+
+	# Modify a different block
+	original.set_block(0, 0, BlockData.BlockType.AIR)
+
+	var data = original.serialize()
+	var restored = TileWorld.deserialize(data)
+
+	assert_eq(restored.get_block(50, 25), gen_block,
+		"Procedurally generated blocks should match after roundtrip")
+
+
+# =============================================================================
+# Miner Serialize/Deserialize Tests
+# =============================================================================
+
+func test_miner_serialize():
+	var miner = Miner.new()
+	miner.position = Vector2(100.0, -200.0)
+	miner.direction = Vector2i.RIGHT
+
+	var data = miner.serialize()
+
+	assert_eq(data["type"], "Miner", "Serialized type should be Miner")
+	assert_eq(data["position"]["x"], 100.0, "Should serialize X position")
+	assert_eq(data["position"]["y"], -200.0, "Should serialize Y position")
+	assert_eq(data["direction"]["x"], 1, "Should serialize direction X")
+	assert_eq(data["direction"]["y"], 0, "Should serialize direction Y")
+	miner.free()
+
+
+func test_miner_serialize_inventory():
+	var miner = Miner.new()
+	miner.get_inventory().add_item(ItemData.ItemType.COAL, 10)
+	miner.get_inventory().add_item(ItemData.ItemType.IRON_ORE, 5)
+
+	var data = miner.serialize()
+
+	assert_true(data.has("inventory"), "Should include inventory")
+	var inv: Array = data["inventory"]
+	assert_eq(inv.size(), 2, "Sparse format should only include non-empty slots")
+
+	# First entry should be slot 0 with coal
+	assert_eq(inv[0]["slot"], 0, "First entry should be slot 0")
+	assert_eq(inv[0]["item"], ItemData.ItemType.COAL, "First slot should be coal")
+	assert_eq(inv[0]["count"], 10, "First slot count should be 10")
+
+	# Second entry should be slot 1 with iron ore
+	assert_eq(inv[1]["slot"], 1, "Second entry should be slot 1")
+	assert_eq(inv[1]["item"], ItemData.ItemType.IRON_ORE, "Second slot should be iron ore")
+	assert_eq(inv[1]["count"], 5, "Second slot count should be 5")
+	miner.free()
+
+
+func test_miner_serialize_state():
+	var miner = Miner.new()
+	miner._state = Miner.State.MINING
+
+	var data = miner.serialize()
+
+	assert_eq(data["state"], Miner.State.MINING, "Should serialize miner state")
+	miner.free()
+
+
+func test_miner_serialize_left_direction():
+	var miner = Miner.new()
+	miner.direction = Vector2i.LEFT
+
+	var data = miner.serialize()
+
+	assert_eq(data["direction"]["x"], -1, "Should serialize LEFT direction X as -1")
+	assert_eq(data["direction"]["y"], 0, "Should serialize LEFT direction Y as 0")
+	miner.free()
+
+
+func test_miner_deserialize_restores_state():
+	var miner = Miner.new()
+	miner._state = Miner.State.IDLE
+
+	miner.deserialize({"state": Miner.State.MINING, "inventory": []})
+
+	assert_eq(miner._state, Miner.State.MINING, "Deserialize should restore state")
+	miner.free()
+
+
+func test_miner_deserialize_restores_inventory():
+	var miner = Miner.new()
+
+	miner.deserialize({
+		"state": Miner.State.IDLE,
+		"inventory": [{"slot": 0, "item": ItemData.ItemType.COAL, "count": 25}],
+	})
+
+	var slot = miner.get_inventory().get_slot(0)
+	assert_eq(slot.item, ItemData.ItemType.COAL, "Deserialize should restore inventory item")
+	assert_eq(slot.count, 25, "Deserialize should restore inventory count")
+	miner.free()
+
+
+func test_miner_serialize_roundtrip():
+	var miner = Miner.new()
+	miner.position = Vector2(50.0, -100.0)
+	miner.direction = Vector2i.LEFT
+	miner._state = Miner.State.MINING
+	miner.get_inventory().add_item(ItemData.ItemType.IRON_ORE, 15)
+
+	var data = miner.serialize()
+
+	# Create a fresh miner and deserialize
+	var restored = Miner.new()
+	restored.position = Vector2(
+		float(data["position"]["x"]),
+		float(data["position"]["y"])
+	)
+	restored.direction = Vector2i(
+		int(data["direction"]["x"]),
+		int(data["direction"]["y"])
+	)
+	restored.deserialize(data)
+
+	assert_eq(restored.position, miner.position, "Position should roundtrip")
+	assert_eq(restored.direction, miner.direction, "Direction should roundtrip")
+	assert_eq(restored._state, Miner.State.MINING, "State should roundtrip")
+	var slot = restored.get_inventory().get_slot(0)
+	assert_eq(slot.item, ItemData.ItemType.IRON_ORE, "Inventory item should roundtrip")
+	assert_eq(slot.count, 15, "Inventory count should roundtrip")
+
+	miner.free()
+	restored.free()
+
+
+# =============================================================================
+# EntitySaver Dispatch Tests
+# =============================================================================
+
+func test_entity_saver_serialize_all_delegates_to_miner():
+	# EntitySaver.serialize_all should call miner.serialize() for each miner
+	var miner = Miner.new()
+	miner.position = Vector2(100.0, -200.0)
+	miner.direction = Vector2i.RIGHT
+	add_child(miner)
+
+	var entities = EntitySaver.serialize_all(get_tree())
+
+	assert_eq(entities.size(), 1, "Should serialize one miner")
+	assert_eq(entities[0]["type"], "Miner", "Should delegate to miner.serialize()")
+	assert_eq(entities[0]["position"]["x"], 100.0, "Should have miner's position")
+
+	miner.queue_free()
+
+
+# =============================================================================
+# PlayerController Serialize/Deserialize Tests
+# =============================================================================
+
+func test_player_controller_serialize():
+	var player = PlayerController.new()
+	player.position = Vector2(160.0, -320.0)
+
+	var data = player.serialize()
+
+	assert_true(data.has("position"), "Should include position")
+	assert_eq(data["position"]["x"], 160.0, "Should serialize X position")
+	assert_eq(data["position"]["y"], -320.0, "Should serialize Y position")
+	player.free()
+
+
+func test_player_controller_deserialize():
+	var player = PlayerController.new()
+	player.position = Vector2.ZERO
+
+	player.deserialize({"position": {"x": 200.0, "y": -400.0}})
+
+	assert_eq(player.position, Vector2(200.0, -400.0), "Should restore position")
+	player.free()
+
+
+func test_player_controller_deserialize_missing_position():
+	var player = PlayerController.new()
+	player.position = Vector2(100.0, 50.0)
+
+	player.deserialize({})
+
+	# Position should remain unchanged when no position data provided
+	assert_eq(player.position, Vector2(100.0, 50.0), "Should not change position if data missing")
+	player.free()
+
+
+func test_player_controller_serialize_roundtrip():
+	var player = PlayerController.new()
+	player.position = Vector2(333.0, -666.0)
+
+	var data = player.serialize()
+
+	var restored = PlayerController.new()
+	restored.deserialize(data)
+
+	assert_eq(restored.position, player.position, "Position should roundtrip")
+	player.free()
+	restored.free()
+
+
+# =============================================================================
+# SaveManager Tests
+# =============================================================================
+
+func test_save_manager_class_exists():
+	var manager = SaveManager.new()
+	assert_not_null(manager, "SaveManager class should exist")
+	manager.free()
+
+
+func test_save_manager_has_save_version():
+	assert_eq(SaveManager.SAVE_VERSION, "0.1.0", "Save version should be 0.1.0")
+
+
+func test_save_manager_has_default_save_file():
+	assert_eq(SaveManager.DEFAULT_SAVE_FILE, "save.json", "Default save file should be save.json")
+
+
+func test_save_manager_auto_save_interval():
+	assert_eq(SaveManager.AUTO_SAVE_INTERVAL, 300.0, "Auto-save interval should be 300 seconds")
+
+
+func test_save_manager_save_fails_without_refs():
+	var manager = SaveManager.new()
+	add_child(manager)
+
+	var result = manager.save_game("test_no_refs.json")
+	assert_false(result, "Save should fail without game references")
+
+	manager.queue_free()
+
+
+func test_save_manager_save_and_load_roundtrip():
+	var manager = SaveManager.new()
+	add_child(manager)
+
+	# Setup game state
+	var world = TileWorld.new(42)
+	world.set_block(5, 10, BlockData.BlockType.STONE)
+
+	var inv = Inventory.new()
+	inv.add_item(ItemData.ItemType.COAL, 20)
+
+	var player_node = _create_test_player()
+	player_node.position = Vector2(160.0, -320.0)
+	add_child(player_node)
+
+	manager.tile_world = world
+	manager.player_inventory = inv
+	manager.player_node = player_node
+	manager.scene_tree = get_tree()
+
+	# Save
+	var save_result = manager.save_game("test_roundtrip.json")
+	assert_true(save_result, "Save should succeed")
+
+	# Verify file exists
+	assert_true(manager.has_save("test_roundtrip.json"), "Save file should exist")
+
+	# Load
+	var data = manager.load_game("test_roundtrip.json")
+	assert_false(data.is_empty(), "Loaded data should not be empty")
+	assert_eq(data["version"], "0.1.0", "Version should match")
+
+	# Verify world data
+	assert_eq(data["world"]["seed"], 42, "World seed should be preserved")
+
+	# Verify player data
+	assert_eq(data["player"]["position"]["x"], 160.0, "Player X should be preserved")
+	assert_eq(data["player"]["position"]["y"], -320.0, "Player Y should be preserved")
+
+	# Verify inventory (sparse format - only non-empty slots)
+	var inv_slots: Array = data["player"]["inventory"]
+	assert_eq(inv_slots.size(), 1, "Sparse inventory should have 1 non-empty slot")
+	assert_eq(inv_slots[0]["slot"], 0, "First entry should be slot 0")
+	assert_eq(inv_slots[0]["item"], ItemData.ItemType.COAL, "Inventory item should be preserved")
+	assert_eq(inv_slots[0]["count"], 20, "Inventory count should be preserved")
+
+	# Cleanup
+	manager.delete_save("test_roundtrip.json")
+	player_node.queue_free()
+	manager.queue_free()
+
+
+func test_save_manager_load_nonexistent_file():
+	var manager = SaveManager.new()
+	add_child(manager)
+
+	var data = manager.load_game("nonexistent_save.json")
+	assert_true(data.is_empty(), "Loading nonexistent file should return empty dict")
+
+	manager.queue_free()
+
+
+func test_save_manager_has_save_returns_false_for_missing():
+	var manager = SaveManager.new()
+	add_child(manager)
+
+	assert_false(manager.has_save("definitely_missing.json"), "has_save should return false for missing file")
+
+	manager.queue_free()
+
+
+func test_save_manager_delete_save():
+	var manager = SaveManager.new()
+	add_child(manager)
+
+	# Setup minimal state
+	var world = TileWorld.new(1)
+	var inv = Inventory.new()
+	var player_node = _create_test_player()
+	add_child(player_node)
+
+	manager.tile_world = world
+	manager.player_inventory = inv
+	manager.player_node = player_node
+	manager.scene_tree = get_tree()
+
+	# Save then delete
+	manager.save_game("test_delete.json")
+	assert_true(manager.has_save("test_delete.json"), "File should exist after save")
+
+	var deleted = manager.delete_save("test_delete.json")
+	assert_true(deleted, "delete_save should return true")
+	assert_false(manager.has_save("test_delete.json"), "File should not exist after delete")
+
+	player_node.queue_free()
+	manager.queue_free()
+
+
+func test_save_manager_save_includes_timestamp():
+	var manager = SaveManager.new()
+	add_child(manager)
+
+	var world = TileWorld.new(1)
+	var inv = Inventory.new()
+	var player_node = _create_test_player()
+	add_child(player_node)
+
+	manager.tile_world = world
+	manager.player_inventory = inv
+	manager.player_node = player_node
+	manager.scene_tree = get_tree()
+
+	manager.save_game("test_timestamp.json")
+	var data = manager.load_game("test_timestamp.json")
+
+	assert_true(data.has("timestamp"), "Save data should include timestamp")
+	assert_true(data["timestamp"] > 0, "Timestamp should be positive")
+
+	manager.delete_save("test_timestamp.json")
+	player_node.queue_free()
+	manager.queue_free()
+
+
+func test_save_manager_save_includes_entities_array():
+	var manager = SaveManager.new()
+	add_child(manager)
+
+	var world = TileWorld.new(1)
+	var inv = Inventory.new()
+	var player_node = _create_test_player()
+	add_child(player_node)
+
+	manager.tile_world = world
+	manager.player_inventory = inv
+	manager.player_node = player_node
+	manager.scene_tree = get_tree()
+
+	manager.save_game("test_entities.json")
+	var data = manager.load_game("test_entities.json")
+
+	assert_true(data.has("entities"), "Save data should include entities array")
+	assert_true(data["entities"] is Array, "Entities should be an array")
+
+	manager.delete_save("test_entities.json")
+	player_node.queue_free()
+	manager.queue_free()
+
+
+# =============================================================================
+# Inventory Serialize/Deserialize Tests
+# =============================================================================
+
+func test_inventory_serialize_empty():
+	var inv = Inventory.new()
+	var data = inv.serialize()
+	assert_eq(data.size(), 0, "Empty inventory should serialize to empty array")
+
+
+func test_inventory_serialize_sparse_format():
+	var inv = Inventory.new()
+	inv.add_item(ItemData.ItemType.COAL, 10)
+
+	var data = inv.serialize()
+	assert_eq(data.size(), 1, "Should only include non-empty slots")
+	assert_eq(data[0]["slot"], 0, "Should include slot index")
+	assert_eq(data[0]["item"], ItemData.ItemType.COAL, "Should include item type")
+	assert_eq(data[0]["count"], 10, "Should include count")
+
+
+func test_inventory_serialize_multiple_items():
+	var inv = Inventory.new()
+	inv.add_item(ItemData.ItemType.COAL, 64)
+	inv.add_item(ItemData.ItemType.IRON_ORE, 32)
+	inv.set_slot(10, ItemData.ItemType.DIAMOND, 5)
+
+	var data = inv.serialize()
+	assert_eq(data.size(), 3, "Should have 3 non-empty slots")
+
+	# Verify slot indices are correct
+	assert_eq(data[0]["slot"], 0, "First entry at slot 0")
+	assert_eq(data[1]["slot"], 1, "Second entry at slot 1")
+	assert_eq(data[2]["slot"], 10, "Third entry at slot 10")
+
+
+func test_inventory_deserialize_clears_existing():
+	var inv = Inventory.new()
+	inv.add_item(ItemData.ItemType.COAL, 50)
+
+	# Deserialize with different data
+	inv.deserialize([{"slot": 5, "item": ItemData.ItemType.DIAMOND, "count": 3}])
+
+	# Slot 0 should be cleared
+	var slot0 = inv.get_slot(0)
+	assert_eq(slot0.item, Inventory.NONE, "Old data should be cleared")
+
+	# Slot 5 should have new data
+	var slot5 = inv.get_slot(5)
+	assert_eq(slot5.item, ItemData.ItemType.DIAMOND, "New data should be restored")
+	assert_eq(slot5.count, 3, "New count should be restored")
+
+
+func test_inventory_deserialize_ignores_invalid_entries():
+	var inv = Inventory.new()
+	# Mix of valid and invalid entries
+	inv.deserialize([
+		{"slot": 0, "item": ItemData.ItemType.COAL, "count": 10},
+		{"bad": "data"},
+		{"slot": -1, "item": 1, "count": 5},
+		{"slot": 999, "item": 1, "count": 5},
+	])
+
+	# Only slot 0 should be set
+	var slot0 = inv.get_slot(0)
+	assert_eq(slot0.item, ItemData.ItemType.COAL, "Valid entry should be applied")
+	assert_eq(slot0.count, 10, "Valid count should be applied")
+
+	# Others should remain empty
+	var slot1 = inv.get_slot(1)
+	assert_eq(slot1.item, Inventory.NONE, "Invalid entries should be ignored")
+
+
+func test_inventory_deserialize_empty_array():
+	var inv = Inventory.new()
+	inv.add_item(ItemData.ItemType.COAL, 10)
+
+	inv.deserialize([])
+
+	# All slots should be cleared
+	var slot0 = inv.get_slot(0)
+	assert_eq(slot0.item, Inventory.NONE, "Deserializing empty array should clear inventory")
+
+
+# =============================================================================
+# Full Integration-style Roundtrip
+# =============================================================================
+
+func test_full_world_save_load_preserves_modifications():
+	# Simulate a play session with modifications
+	var world = TileWorld.new(42)
+
+	# Mine some blocks (set to AIR)
+	world.set_block(5, 30, BlockData.BlockType.AIR)
+	world.set_block(6, 30, BlockData.BlockType.AIR)
+	world.set_block(7, 30, BlockData.BlockType.AIR)
+
+	# Place some blocks
+	world.set_block(10, 50, BlockData.BlockType.COBBLESTONE)
+	world.set_block(11, 50, BlockData.BlockType.PLANKS)
+
+	# Serialize
+	var data = world.serialize()
+
+	# Deserialize into new world
+	var restored = TileWorld.deserialize(data)
+
+	# Verify mined blocks are still AIR
+	assert_eq(restored.get_block(5, 30), BlockData.BlockType.AIR, "Mined block should stay AIR")
+	assert_eq(restored.get_block(6, 30), BlockData.BlockType.AIR, "Mined block should stay AIR")
+	assert_eq(restored.get_block(7, 30), BlockData.BlockType.AIR, "Mined block should stay AIR")
+
+	# Verify placed blocks
+	assert_eq(restored.get_block(10, 50), BlockData.BlockType.COBBLESTONE, "Placed block should persist")
+	assert_eq(restored.get_block(11, 50), BlockData.BlockType.PLANKS, "Placed block should persist")
+
+	# Verify unmodified terrain regenerates identically
+	var fresh = TileWorld.new(42)
+	for x in range(-10, 10):
+		for y in range(0, 40):
+			if Vector2i(x, y) not in [Vector2i(5, 30), Vector2i(6, 30), Vector2i(7, 30),
+									   Vector2i(10, 50), Vector2i(11, 50)]:
+				assert_eq(restored.get_block(x, y), fresh.get_block(x, y),
+					"Unmodified block at (%d,%d) should match fresh generation" % [x, y])
+
+
+func test_inventory_roundtrip_preserves_all_slots():
+	var inv = Inventory.new()
+	inv.add_item(ItemData.ItemType.COAL, 64)
+	inv.add_item(ItemData.ItemType.IRON_ORE, 32)
+	inv.add_item(ItemData.ItemType.DIAMOND, 1)
+
+	# Serialize using Inventory's own method
+	var data = inv.serialize()
+
+	# Deserialize into new inventory
+	var restored = Inventory.new()
+	restored.deserialize(data)
+
+	# Verify all slots match
+	for i in range(inv.size):
+		var original_slot = inv.get_slot(i)
+		var restored_slot = restored.get_slot(i)
+		assert_eq(restored_slot.item, original_slot.item,
+			"Slot %d item should match after roundtrip" % i)
+		assert_eq(restored_slot.count, original_slot.count,
+			"Slot %d count should match after roundtrip" % i)
+
+
+func test_save_data_format_matches_spec():
+	# Verify the JSON structure matches the issue specification
+	var manager = SaveManager.new()
+	add_child(manager)
+
+	var world = TileWorld.new(12345)
+	world.set_block(0, 0, BlockData.BlockType.STONE)
+
+	var inv = Inventory.new()
+	inv.add_item(ItemData.ItemType.MINER, 1)
+
+	var player_node = _create_test_player()
+	player_node.position = Vector2(100.0, 50.0)
+	add_child(player_node)
+
+	manager.tile_world = world
+	manager.player_inventory = inv
+	manager.player_node = player_node
+	manager.scene_tree = get_tree()
+
+	manager.save_game("test_format.json")
+	var data = manager.load_game("test_format.json")
+
+	# Verify top-level keys per spec
+	assert_true(data.has("version"), "Should have 'version' key")
+	assert_true(data.has("world"), "Should have 'world' key")
+	assert_true(data.has("player"), "Should have 'player' key")
+	assert_true(data.has("entities"), "Should have 'entities' key")
+
+	# Verify world structure
+	assert_true(data["world"].has("seed"), "World should have 'seed'")
+
+	# Verify player structure
+	assert_true(data["player"].has("position"), "Player should have 'position'")
+	assert_true(data["player"]["position"].has("x"), "Position should have 'x'")
+	assert_true(data["player"]["position"].has("y"), "Position should have 'y'")
+	assert_true(data["player"].has("inventory"), "Player should have 'inventory'")
+
+	manager.delete_save("test_format.json")
+	player_node.queue_free()
+	manager.queue_free()

--- a/game/tests/unit/test_save_system.gd.uid
+++ b/game/tests/unit/test_save_system.gd.uid
@@ -1,0 +1,1 @@
+uid://dlh3mbrwg1614


### PR DESCRIPTION
## Summary

- Implement JSON-based save/load persistence for world state, player data, and entity states (closes #7)
- Each class owns its own `serialize()`/`deserialize()` methods — no centralized serialization logic
- World saves use delta-only format (only player-modified tiles are persisted; procedural terrain regenerates from seed)
- Inventory uses sparse format (only non-empty slots serialized)
- F5 to save, F9 to load, with auto-save support

## Changes

### New files
- `game/scripts/save/save_manager.gd` — Orchestrates save/load, delegates to owning classes
- `game/scripts/save/entity_saver.gd` — Thin dispatcher for entity serialization
- `game/tests/unit/test_save_system.gd` — 46 tests covering all serialization logic

### Modified files
- `game/scripts/world/tile_world.gd` — Added `serialize()`, static `deserialize()`, modified tile tracking
- `game/scripts/player/player_controller.gd` — Added `serialize()` / `deserialize()` for position
- `game/scripts/components/inventory.gd` — Added `serialize()` / `deserialize()` with sparse slot format
- `game/scripts/entities/miner.gd` — Added `serialize()` / `deserialize()` for full miner state
- `game/scripts/main.gd` — Save/load lifecycle, auto-save setup, load-time world/entity restoration
- `game/scripts/player/input_manager.gd` — F5/F9 keybindings with `save_requested`/`load_requested` signals
- `game/scripts/rendering/world_renderer.gd` — `set_tile_world()` now calls `clear()` to fix chunk rendering on load
- `game/project.godot` — Added `save_game` and `load_game` input actions
- `game/tests/unit/test_world_renderer.gd` — Fixed `test_moving_target_loads_new_chunks` to match viewport-based chunking

## Testing

All 557 tests pass (46 new save system tests + 511 existing).