### PR TITLE
Implement item entities - visual items in world (closes #10)

### DIFF
--- a/game/scenes/entities/item_entity.tscn
+++ b/game/scenes/entities/item_entity.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=3 format=3 uid="uid://item_entity_scene_001"]
+
+[ext_resource type="Script" path="res://scripts/entities/item_entity.gd" id="1_script"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_pickup"]
+radius = 10.0
+
+[node name="ItemEntity" type="Area2D"]
+collision_layer = 4
+collision_mask = 1
+monitorable = true
+monitoring = true
+script = ExtResource("1_script")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("CircleShape2D_pickup")
+
+[node name="Sprite" type="ColorRect" parent="."]
+offset_left = -5.0
+offset_top = -5.0
+offset_right = 5.0
+offset_bottom = 5.0
+color = Color(0.5, 0.5, 0.5, 1)
+
+[node name="CountLabel" type="Label" parent="."]
+offset_left = -10.0
+offset_top = 5.0
+offset_right = 10.0
+offset_bottom = 19.0
+horizontal_alignment = 1

--- a/game/scripts/entities/item_entity.gd
+++ b/game/scripts/entities/item_entity.gd
@@ -1,0 +1,386 @@
+## ItemEntity - A visual item that exists in the game world
+## Can be picked up by the player, output from miners, or ride conveyor belts.
+## Nearby items of the same type merge (stack) on the ground.
+## Despawns after a configurable timeout.
+class_name ItemEntity
+extends Area2D
+
+# =============================================================================
+# Signals
+# =============================================================================
+signal picked_up(item_type: int, count: int)
+signal despawned(item_type: int, count: int)
+signal merged(item_type: int, new_count: int)
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+## How close two items must be (in pixels) to merge
+const MERGE_RADIUS: float = 24.0
+
+## How often to check for nearby items to merge with (seconds)
+const MERGE_CHECK_INTERVAL: float = 0.5
+
+## Default time before a dropped item despawns (seconds). 0 = never.
+const DEFAULT_DESPAWN_TIME: float = 300.0
+
+## Short pickup immunity after spawning so the player doesn't instantly grab drops
+const PICKUP_DELAY: float = 0.5
+
+## Bobbing animation amplitude (pixels)
+const BOB_AMPLITUDE: float = 2.0
+
+## Bobbing animation speed (radians per second)
+const BOB_SPEED: float = 3.0
+
+## Size of the item sprite (pixels, square)
+const SPRITE_SIZE: float = 10.0
+
+## Item-type to color mapping for visual representation
+## Until real sprite assets exist, each item type gets a distinct color.
+static var _item_colors: Dictionary = {
+	ItemData.ItemType.DIRT: Color(0.55, 0.35, 0.18),
+	ItemData.ItemType.STONE: Color(0.5, 0.5, 0.5),
+	ItemData.ItemType.WOOD: Color(0.55, 0.35, 0.05),
+	ItemData.ItemType.LEAVES: Color(0.2, 0.55, 0.15),
+	ItemData.ItemType.SAND: Color(0.85, 0.8, 0.55),
+	ItemData.ItemType.GRASS: Color(0.3, 0.6, 0.2),
+	ItemData.ItemType.COBBLESTONE: Color(0.45, 0.45, 0.45),
+	ItemData.ItemType.PLANKS: Color(0.7, 0.5, 0.25),
+	ItemData.ItemType.BEDROCK: Color(0.2, 0.2, 0.2),
+	ItemData.ItemType.COAL: Color(0.15, 0.15, 0.15),
+	ItemData.ItemType.IRON_ORE: Color(0.7, 0.55, 0.45),
+	ItemData.ItemType.GOLD_ORE: Color(0.85, 0.75, 0.2),
+	ItemData.ItemType.IRON_INGOT: Color(0.75, 0.75, 0.75),
+	ItemData.ItemType.GOLD_INGOT: Color(0.95, 0.85, 0.15),
+	ItemData.ItemType.DIAMOND: Color(0.4, 0.85, 0.9),
+}
+
+# =============================================================================
+# Properties
+# =============================================================================
+
+## The type of item this entity represents
+var item_type: int = ItemData.ItemType.NONE
+
+## How many of this item are stacked
+var count: int = 1
+
+## Whether this item can currently be picked up
+var _pickup_ready: bool = false
+
+## Time accumulator for bobbing animation
+var _bob_time: float = 0.0
+
+## Base Y position for bobbing (set on spawn)
+var _base_y: float = 0.0
+
+## Time accumulator for merge checks
+var _merge_timer: float = 0.0
+
+## Whether this item is currently on a conveyor belt
+var on_belt: bool = false
+
+## Whether this entity is being absorbed by a merge (will be freed)
+var _merging: bool = false
+
+## Reference to the visual ColorRect (created in _ready or setup)
+var _sprite: ColorRect
+
+## Reference to the count label
+var _count_label: Label
+
+## Reference to the collision shape
+var _collision_shape: CollisionShape2D
+
+## Despawn timer node
+var _despawn_timer: Timer
+
+
+# =============================================================================
+# Lifecycle
+# =============================================================================
+
+func _ready() -> void:
+	add_to_group("item_entities")
+	_base_y = position.y
+
+	# Create visual nodes if not already present (scene instantiation adds them)
+	if not has_node("Sprite"):
+		_create_visuals()
+	else:
+		_sprite = $Sprite
+		_count_label = $CountLabel
+		_collision_shape = $CollisionShape2D
+
+	_update_visuals()
+
+	# Pickup delay
+	_pickup_ready = false
+	var pickup_timer := get_tree().create_timer(PICKUP_DELAY)
+	pickup_timer.timeout.connect(func(): _pickup_ready = true)
+
+	# Connect body entered for player pickup
+	body_entered.connect(_on_body_entered)
+
+
+func _process(delta: float) -> void:
+	if _merging:
+		return
+
+	# Bobbing animation (only when not on belt)
+	if not on_belt:
+		_bob_time += delta
+		position.y = _base_y + sin(_bob_time * BOB_SPEED) * BOB_AMPLITUDE
+
+	# Periodic merge check
+	_merge_timer += delta
+	if _merge_timer >= MERGE_CHECK_INTERVAL:
+		_merge_timer = 0.0
+		_try_merge_nearby()
+
+
+# =============================================================================
+# Public API
+# =============================================================================
+
+## Initialize this item entity with a type, count, and world position.
+## Call after instantiation but before adding to the scene tree, or in _ready.
+func setup(p_item_type: int, p_count: int, world_pos: Vector2, p_despawn_time: float = DEFAULT_DESPAWN_TIME) -> void:
+	item_type = p_item_type
+	count = p_count
+	position = world_pos
+	_base_y = world_pos.y
+
+	if is_inside_tree():
+		_update_visuals()
+		_setup_despawn_timer(p_despawn_time)
+
+
+## Try to pick up this item into the given inventory.
+## Returns the number of items actually picked up (may be less than count if inventory full).
+func try_pickup(inventory: Inventory) -> int:
+	if not _pickup_ready or _merging:
+		return 0
+
+	var remaining := inventory.add_item(item_type, count)
+	var picked := count - remaining
+
+	if picked > 0:
+		picked_up.emit(item_type, picked)
+		if remaining <= 0:
+			queue_free()
+		else:
+			count = remaining
+			_update_visuals()
+
+	return picked
+
+
+## Get the max stack size for this item type
+func get_max_stack() -> int:
+	return ItemData.get_max_stack(item_type)
+
+
+## Serialize this item entity for saving
+func serialize() -> Dictionary:
+	return {
+		"type": "ItemEntity",
+		"item_type": item_type,
+		"count": count,
+		"position": {"x": position.x, "y": _base_y},
+		"on_belt": on_belt,
+	}
+
+
+## Restore state from saved data. Call after adding to scene tree.
+func deserialize(data: Dictionary) -> void:
+	item_type = int(data.get("item_type", ItemData.ItemType.NONE))
+	count = int(data.get("count", 1))
+	on_belt = data.get("on_belt", false)
+
+	var pos_data: Dictionary = data.get("position", {})
+	position = Vector2(
+		float(pos_data.get("x", 0.0)),
+		float(pos_data.get("y", 0.0))
+	)
+	_base_y = position.y
+
+	_update_visuals()
+
+
+# =============================================================================
+# Pickup
+# =============================================================================
+
+func _on_body_entered(body: Node2D) -> void:
+	if not _pickup_ready or _merging:
+		return
+
+	if body is PlayerController:
+		# Find the player's inventory via the Main scene
+		var main := _get_main()
+		if main and main.inventory:
+			try_pickup(main.inventory)
+
+
+func _get_main() -> Main:
+	var node := get_tree().current_scene
+	if node is Main:
+		return node as Main
+	return null
+
+
+# =============================================================================
+# Merging
+# =============================================================================
+
+func _try_merge_nearby() -> void:
+	if _merging or not is_inside_tree():
+		return
+
+	var max_stack := get_max_stack()
+	if count >= max_stack:
+		return
+
+	var items := get_tree().get_nodes_in_group("item_entities")
+	for node in items:
+		if node == self or not is_instance_valid(node):
+			continue
+		var other: ItemEntity = node as ItemEntity
+		if other == null or other._merging:
+			continue
+		if other.item_type != item_type:
+			continue
+		if other.on_belt or on_belt:
+			continue
+
+		var dist := position.distance_to(other.position)
+		if dist > MERGE_RADIUS:
+			continue
+
+		# Merge other into self
+		var space := max_stack - count
+		if space <= 0:
+			break
+
+		var to_merge := mini(other.count, space)
+		count += to_merge
+		other.count -= to_merge
+
+		if other.count <= 0:
+			other._merging = true
+			other.queue_free()
+		else:
+			other._update_visuals()
+
+		merged.emit(item_type, count)
+		_update_visuals()
+
+		if count >= max_stack:
+			break
+
+
+# =============================================================================
+# Despawn
+# =============================================================================
+
+func _setup_despawn_timer(time: float) -> void:
+	if time <= 0.0:
+		return
+
+	if _despawn_timer != null:
+		_despawn_timer.queue_free()
+
+	_despawn_timer = Timer.new()
+	_despawn_timer.one_shot = true
+	_despawn_timer.wait_time = time
+	_despawn_timer.timeout.connect(_on_despawn)
+	add_child(_despawn_timer)
+	_despawn_timer.start()
+
+
+func _on_despawn() -> void:
+	despawned.emit(item_type, count)
+	queue_free()
+
+
+## Reset the despawn timer (e.g. after a merge)
+func reset_despawn_timer() -> void:
+	if _despawn_timer and is_instance_valid(_despawn_timer):
+		_despawn_timer.start()
+
+
+# =============================================================================
+# Visuals
+# =============================================================================
+
+func _create_visuals() -> void:
+	# Collision shape for pickup detection
+	_collision_shape = CollisionShape2D.new()
+	var shape := CircleShape2D.new()
+	shape.radius = SPRITE_SIZE
+	_collision_shape.shape = shape
+	_collision_shape.name = "CollisionShape2D"
+	add_child(_collision_shape)
+
+	# Simple colored square as placeholder sprite
+	_sprite = ColorRect.new()
+	_sprite.name = "Sprite"
+	_sprite.size = Vector2(SPRITE_SIZE, SPRITE_SIZE)
+	_sprite.position = Vector2(-SPRITE_SIZE / 2.0, -SPRITE_SIZE / 2.0)
+	add_child(_sprite)
+
+	# Count label (shown when count > 1)
+	_count_label = Label.new()
+	_count_label.name = "CountLabel"
+	_count_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_count_label.position = Vector2(-SPRITE_SIZE, SPRITE_SIZE / 2.0)
+	_count_label.size = Vector2(SPRITE_SIZE * 2, 14)
+	_count_label.add_theme_font_size_override("font_size", 8)
+	add_child(_count_label)
+
+
+func _update_visuals() -> void:
+	if _sprite:
+		_sprite.color = _get_item_color(item_type)
+	if _count_label:
+		if count > 1:
+			_count_label.text = str(count)
+			_count_label.visible = true
+		else:
+			_count_label.text = ""
+			_count_label.visible = false
+
+
+static func _get_item_color(p_item_type: int) -> Color:
+	if _item_colors.has(p_item_type):
+		return _item_colors[p_item_type]
+	# Fallback: generate a color from the item type id
+	var hue := fmod(float(p_item_type) * 0.618033988749, 1.0)
+	return Color.from_hsv(hue, 0.6, 0.8)
+
+
+# =============================================================================
+# Factory
+# =============================================================================
+
+## Convenience: create and configure an ItemEntity, add it to a parent node.
+## Returns the new ItemEntity.
+static func spawn(parent: Node, p_item_type: int, p_count: int, world_pos: Vector2, p_despawn_time: float = DEFAULT_DESPAWN_TIME) -> ItemEntity:
+	var scene := load("res://scenes/entities/item_entity.tscn")
+	if scene == null:
+		push_error("ItemEntity scene not found at res://scenes/entities/item_entity.tscn")
+		return null
+
+	var entity: ItemEntity = scene.instantiate()
+	entity.item_type = p_item_type
+	entity.count = p_count
+	entity.position = world_pos
+	entity._base_y = world_pos.y
+	parent.add_child(entity)
+
+	# Setup despawn after adding to tree so timer works
+	entity._setup_despawn_timer(p_despawn_time)
+	return entity

--- a/game/scripts/entities/item_entity.gd.uid
+++ b/game/scripts/entities/item_entity.gd.uid
@@ -1,0 +1,1 @@
+uid://od1ic6kebdia

--- a/game/scripts/entities/miner.gd
+++ b/game/scripts/entities/miner.gd
@@ -158,13 +158,26 @@ func _complete_mining(block_type: int) -> void:
 	if drops.item != "" and drops.count > 0:
 		var item_type = ItemData.get_type_from_name(drops.item)
 		if item_type != ItemData.ItemType.NONE:
-			get_inventory().add_item(item_type, drops.count)
+			var remaining := get_inventory().add_item(item_type, drops.count)
+			# If inventory is full, spawn item entity in the world
+			if remaining > 0:
+				_spawn_item_drop(item_type, remaining)
 
 	# Remove block
 	tile_world.set_block(_current_mining_block_pos.x, _current_mining_block_pos.y, BlockData.BlockType.AIR)
 
 	# Resume moving
 	_state = State.MOVING
+
+
+## Spawn a dropped item entity behind the miner (opposite of mining direction)
+func _spawn_item_drop(item_type: int, item_count: int) -> void:
+	if not is_inside_tree():
+		return
+	# Drop behind the miner (opposite direction from where it's mining)
+	var drop_offset := Vector2(-direction.x * WorldUtils.TILE_SIZE, 0)
+	var drop_pos := position + drop_offset
+	ItemEntity.spawn(get_parent(), item_type, item_count, drop_pos)
 
 ## Returns the Inventory component
 func get_inventory() -> Inventory:

--- a/game/scripts/main.gd
+++ b/game/scripts/main.gd
@@ -136,8 +136,9 @@ func _on_pause_load_requested() -> void:
 
 
 func _on_load_requested() -> void:
-	# Remove existing miners before loading
+	# Remove existing miners and item entities before loading
 	_remove_all_miners()
+	_remove_all_item_entities()
 
 	var data := save_manager.load_game()
 	if data.is_empty():
@@ -224,6 +225,12 @@ func _remove_all_miners() -> void:
 	for miner in get_tree().get_nodes_in_group("miners"):
 		if is_instance_valid(miner):
 			miner.queue_free()
+
+
+func _remove_all_item_entities() -> void:
+	for item in get_tree().get_nodes_in_group("item_entities"):
+		if is_instance_valid(item):
+			item.queue_free()
 
 
 func _spawn_player_above_terrain() -> void:

--- a/game/scripts/player/mining_controller.gd
+++ b/game/scripts/player/mining_controller.gd
@@ -65,11 +65,17 @@ func try_mine_at(world_position: Vector2) -> bool:
 	# Remove block (set to air)
 	tile_world.set_block(tile_pos.x, tile_pos.y, BlockData.BlockType.AIR)
 
-	# Add drops to inventory
+	# Add drops to inventory (overflow spawns as item entity)
 	if drops.has("item") and drops.item != "":
 		var item_type = _get_item_type_from_name(drops.item)
 		if item_type != ItemData.ItemType.NONE:
-			inventory.add_item(item_type, drops.count)
+			var remaining := inventory.add_item(item_type, drops.count)
+			if remaining > 0:
+				# Spawn overflow as item entity at the mined block position
+				var drop_pos := WorldUtils.tile_to_world(tile_pos) + Vector2(WorldUtils.TILE_SIZE / 2.0, WorldUtils.TILE_SIZE / 2.0)
+				var parent := get_parent()
+				if parent:
+					ItemEntity.spawn(parent, item_type, remaining, drop_pos)
 
 	block_mined.emit(tile_pos, block_type)
 	return true

--- a/game/scripts/save/entity_saver.gd
+++ b/game/scripts/save/entity_saver.gd
@@ -13,6 +13,10 @@ static func serialize_all(tree: SceneTree) -> Array:
 	for miner in tree.get_nodes_in_group("miners"):
 		if miner is Miner and is_instance_valid(miner):
 			entities.append(miner.serialize())
+	# Serialize item entities (only ground items, not belt items)
+	for item in tree.get_nodes_in_group("item_entities"):
+		if item is ItemEntity and is_instance_valid(item) and not item.on_belt:
+			entities.append(item.serialize())
 	return entities
 
 
@@ -27,6 +31,10 @@ static func deserialize_all(entities_data: Array, parent: Node, tile_world: Tile
 				var miner := _instantiate_miner(entity_data, parent, tile_world)
 				if miner:
 					result.append(miner)
+			"ItemEntity":
+				var item := _instantiate_item_entity(entity_data, parent)
+				if item:
+					result.append(item)
 	return result
 
 
@@ -55,3 +63,16 @@ static func _instantiate_miner(data: Dictionary, parent: Node, tile_world: TileW
 	miner.deserialize(data)
 
 	return miner
+
+
+## Instantiate an item entity from saved data, add to scene, and restore state.
+static func _instantiate_item_entity(data: Dictionary, parent: Node) -> ItemEntity:
+	var item_scene := load("res://scenes/entities/item_entity.tscn")
+	if item_scene == null:
+		return null
+
+	var item: ItemEntity = item_scene.instantiate()
+	parent.add_child(item)
+	item.deserialize(data)
+
+	return item

--- a/game/scripts/systems/belt_system.gd
+++ b/game/scripts/systems/belt_system.gd
@@ -1,10 +1,17 @@
 ## BeltSystem for processing conveyor belt item transport
-## Manages all registered belts and handles item movement/transfer
+## Manages all registered belts and handles item movement/transfer.
+## Spawns visual ItemEntity nodes that move along belt segments.
 class_name BeltSystem
 extends System
 
 ## Array of all registered belt nodes
 var belts: Array[BeltNode] = []
+
+## Parent node for spawning dropped item entities (set by Main or owner)
+var item_drop_parent: Node = null
+
+## Signal emitted when an item falls off the end of a belt with no connection
+signal item_dropped(item_type: int, world_pos: Vector2)
 
 
 func _init() -> void:
@@ -31,11 +38,19 @@ func process_belts(delta: float) -> void:
 	for belt in belts:
 		var completed := belt.tick(delta)
 
+		# Update visual positions for items still on this belt
+		_update_belt_item_visuals(belt)
+
 		# Queue transfers for items that completed
 		for item in completed:
 			if belt.next_belt:
 				transfers.append({"belt": belt.next_belt, "item_type": item["item_type"]})
-			# If no next belt, items fall off (could emit signal in future)
+			else:
+				# Item fell off the end of the belt — spawn as world item
+				var drop_pos := _belt_end_world_pos(belt)
+				item_dropped.emit(item["item_type"], drop_pos)
+				if item_drop_parent and is_instance_valid(item_drop_parent):
+					ItemEntity.spawn(item_drop_parent, item["item_type"], 1, drop_pos)
 
 	# Second pass: apply all transfers
 	for transfer in transfers:
@@ -48,3 +63,77 @@ func get_belt_at(pos: Vector2i) -> BeltNode:
 		if belt.position == pos:
 			return belt
 	return null
+
+
+## Update visual positions of ItemEntity nodes riding a belt segment.
+## Items on belts are represented as ItemEntity nodes with `on_belt = true`.
+func _update_belt_item_visuals(belt: BeltNode) -> void:
+	if belt.entity == null or not is_instance_valid(belt.entity):
+		return
+
+	var belt_entity: Node2D = belt.entity as Node2D
+	if belt_entity == null:
+		return
+
+	# Get direction vector for interpolation
+	var dir_vec := _belt_direction_vector(belt.direction)
+	var tile_size := float(WorldUtils.TILE_SIZE)
+
+	# Match visual item entities to belt item data
+	# We look for ItemEntity children of the belt's entity node
+	var visual_items := _get_belt_visual_items(belt_entity)
+	var data_items := belt.get_items()
+
+	# Spawn missing visuals
+	while visual_items.size() < data_items.size():
+		var idx := visual_items.size()
+		var item_data: Dictionary = data_items[idx]
+		var item_entity := ItemEntity.new()
+		item_entity.item_type = item_data["item_type"]
+		item_entity.count = 1
+		item_entity.on_belt = true
+		item_entity.name = "BeltItem_%d" % idx
+		item_entity.add_to_group("item_entities")
+		belt_entity.add_child(item_entity)
+		visual_items.append(item_entity)
+
+	# Remove excess visuals
+	while visual_items.size() > data_items.size():
+		var excess: ItemEntity = visual_items.pop_back()
+		if is_instance_valid(excess):
+			excess.queue_free()
+
+	# Update positions based on progress
+	for i in range(data_items.size()):
+		if i < visual_items.size() and is_instance_valid(visual_items[i]):
+			var progress: float = data_items[i]["progress"]
+			visual_items[i].position = dir_vec * progress * tile_size
+
+
+## Get all ItemEntity children of a belt entity node
+func _get_belt_visual_items(belt_entity: Node2D) -> Array:
+	var result: Array = []
+	for child in belt_entity.get_children():
+		if child is ItemEntity and child.on_belt:
+			result.append(child)
+	return result
+
+
+## Calculate the world position at the end of a belt segment
+func _belt_end_world_pos(belt: BeltNode) -> Vector2:
+	var dir_vec := _belt_direction_vector(belt.direction)
+	return WorldUtils.tile_to_world(belt.position) + dir_vec * float(WorldUtils.TILE_SIZE)
+
+
+## Convert BeltNode.Direction to a Vector2 direction
+func _belt_direction_vector(dir: BeltNode.Direction) -> Vector2:
+	match dir:
+		BeltNode.Direction.RIGHT:
+			return Vector2(1, 0)
+		BeltNode.Direction.LEFT:
+			return Vector2(-1, 0)
+		BeltNode.Direction.UP:
+			return Vector2(0, -1)  # Screen Y is inverted
+		BeltNode.Direction.DOWN:
+			return Vector2(0, 1)
+	return Vector2.ZERO

--- a/game/tests/unit/test_item_entity.gd
+++ b/game/tests/unit/test_item_entity.gd
@@ -1,0 +1,495 @@
+extends GutTest
+## Unit tests for ItemEntity - visual items that exist in the game world
+
+# =============================================================================
+# Basic Existence and Structure
+# =============================================================================
+
+func test_item_entity_exists():
+	var entity = ItemEntity.new()
+	assert_not_null(entity, "ItemEntity should be instantiable")
+	entity.free()
+
+
+func test_item_entity_extends_area2d():
+	var entity = ItemEntity.new()
+	assert_true(entity is Area2D, "ItemEntity should extend Area2D")
+	entity.free()
+
+
+func test_item_entity_default_values():
+	var entity = ItemEntity.new()
+	assert_eq(entity.item_type, ItemData.ItemType.NONE, "Default item_type should be NONE")
+	assert_eq(entity.count, 1, "Default count should be 1")
+	assert_false(entity.on_belt, "Default on_belt should be false")
+	entity.free()
+
+
+# =============================================================================
+# Setup
+# =============================================================================
+
+func test_item_entity_setup_sets_properties():
+	var entity = ItemEntity.new()
+	add_child(entity)
+	entity.setup(ItemData.ItemType.DIRT, 5, Vector2(100, 200))
+	assert_eq(entity.item_type, ItemData.ItemType.DIRT, "setup should set item_type")
+	assert_eq(entity.count, 5, "setup should set count")
+	assert_eq(entity.position, Vector2(100, 200), "setup should set position")
+	entity.queue_free()
+
+
+func test_item_entity_setup_stores_base_y():
+	var entity = ItemEntity.new()
+	add_child(entity)
+	entity.setup(ItemData.ItemType.STONE, 1, Vector2(50, 150))
+	assert_eq(entity._base_y, 150.0, "setup should store base_y for bobbing animation")
+	entity.queue_free()
+
+
+# =============================================================================
+# Color Mapping
+# =============================================================================
+
+func test_item_entity_has_color_for_dirt():
+	var color = ItemEntity._get_item_color(ItemData.ItemType.DIRT)
+	assert_not_null(color, "Should return a color for DIRT")
+	assert_ne(color, Color.BLACK, "Color should not be black")
+
+
+func test_item_entity_has_color_for_stone():
+	var color = ItemEntity._get_item_color(ItemData.ItemType.STONE)
+	assert_not_null(color, "Should return a color for STONE")
+
+
+func test_item_entity_has_color_for_diamond():
+	var color = ItemEntity._get_item_color(ItemData.ItemType.DIAMOND)
+	assert_not_null(color, "Should return a color for DIAMOND")
+
+
+func test_item_entity_fallback_color_for_unknown():
+	var color = ItemEntity._get_item_color(999)
+	assert_not_null(color, "Should return a fallback color for unknown item type")
+
+
+func test_item_entity_different_items_have_different_colors():
+	var dirt_color = ItemEntity._get_item_color(ItemData.ItemType.DIRT)
+	var stone_color = ItemEntity._get_item_color(ItemData.ItemType.STONE)
+	assert_ne(dirt_color, stone_color, "Different items should have different colors")
+
+
+# =============================================================================
+# Serialization
+# =============================================================================
+
+func test_item_entity_serialize():
+	var entity = ItemEntity.new()
+	entity.item_type = ItemData.ItemType.COAL
+	entity.count = 10
+	entity.position = Vector2(64, -128)
+	entity._base_y = -128.0
+
+	var data = entity.serialize()
+	assert_eq(data["type"], "ItemEntity", "Serialized type should be 'ItemEntity'")
+	assert_eq(data["item_type"], ItemData.ItemType.COAL, "Serialized item_type should match")
+	assert_eq(data["count"], 10, "Serialized count should match")
+	assert_eq(data["position"]["x"], 64.0, "Serialized position.x should match")
+	assert_eq(data["position"]["y"], -128.0, "Serialized position.y should match")
+	assert_eq(data["on_belt"], false, "Serialized on_belt should match")
+	entity.free()
+
+
+func test_item_entity_deserialize():
+	var entity = ItemEntity.new()
+	add_child(entity)
+	var data = {
+		"type": "ItemEntity",
+		"item_type": ItemData.ItemType.GOLD_ORE,
+		"count": 3,
+		"position": {"x": 32.0, "y": -64.0},
+		"on_belt": false,
+	}
+	entity.deserialize(data)
+	assert_eq(entity.item_type, ItemData.ItemType.GOLD_ORE, "Deserialized item_type should match")
+	assert_eq(entity.count, 3, "Deserialized count should match")
+	assert_eq(entity.position.x, 32.0, "Deserialized position.x should match")
+	assert_eq(entity.position.y, -64.0, "Deserialized position.y should match")
+	assert_eq(entity._base_y, -64.0, "Deserialized base_y should match position.y")
+	entity.queue_free()
+
+
+func test_item_entity_serialize_roundtrip():
+	var entity1 = ItemEntity.new()
+	entity1.item_type = ItemData.ItemType.IRON_INGOT
+	entity1.count = 7
+	entity1.position = Vector2(200, -300)
+	entity1._base_y = -300.0
+
+	var data = entity1.serialize()
+	entity1.free()
+
+	var entity2 = ItemEntity.new()
+	add_child(entity2)
+	entity2.deserialize(data)
+
+	assert_eq(entity2.item_type, ItemData.ItemType.IRON_INGOT, "Roundtrip item_type should match")
+	assert_eq(entity2.count, 7, "Roundtrip count should match")
+	assert_eq(entity2.position.x, 200.0, "Roundtrip position.x should match")
+	assert_eq(entity2.position.y, -300.0, "Roundtrip position.y should match")
+	entity2.queue_free()
+
+
+# =============================================================================
+# Pickup
+# =============================================================================
+
+func test_item_entity_try_pickup_adds_to_inventory():
+	var entity = ItemEntity.new()
+	entity.item_type = ItemData.ItemType.STONE
+	entity.count = 5
+	entity._pickup_ready = true
+	add_child(entity)
+
+	var inventory = Inventory.new()
+	var picked = entity.try_pickup(inventory)
+
+	assert_eq(picked, 5, "Should pick up all 5 items")
+	assert_true(inventory.has_item(ItemData.ItemType.STONE, 5), "Inventory should have 5 stone")
+	# Entity will be freed via queue_free, handled by engine
+
+
+func test_item_entity_try_pickup_not_ready():
+	var entity = ItemEntity.new()
+	entity.item_type = ItemData.ItemType.STONE
+	entity.count = 5
+	entity._pickup_ready = false
+	add_child(entity)
+
+	var inventory = Inventory.new()
+	var picked = entity.try_pickup(inventory)
+
+	assert_eq(picked, 0, "Should not pick up when not ready")
+	assert_false(inventory.has_item(ItemData.ItemType.STONE, 1), "Inventory should be empty")
+	entity.queue_free()
+
+
+func test_item_entity_try_pickup_partial():
+	var entity = ItemEntity.new()
+	entity.item_type = ItemData.ItemType.DIRT
+	entity.count = 100
+	entity._pickup_ready = true
+	add_child(entity)
+
+	# Create a nearly full inventory (1 slot, max 64)
+	var inventory = Inventory.new()
+	inventory.size = 1
+	inventory._initialize_slots()
+	inventory.add_item(ItemData.ItemType.DIRT, 60) # 4 space left
+
+	var picked = entity.try_pickup(inventory)
+	assert_eq(picked, 4, "Should pick up only what fits (4 items)")
+	assert_eq(entity.count, 96, "Entity should have 96 items remaining")
+	entity.queue_free()
+
+
+func test_item_entity_try_pickup_emits_signal():
+	var entity = ItemEntity.new()
+	entity.item_type = ItemData.ItemType.WOOD
+	entity.count = 3
+	entity._pickup_ready = true
+	add_child(entity)
+
+	watch_signals(entity)
+	var inventory = Inventory.new()
+	entity.try_pickup(inventory)
+
+	assert_signal_emitted(entity, "picked_up", "Should emit picked_up signal")
+
+
+func test_item_entity_try_pickup_when_merging():
+	var entity = ItemEntity.new()
+	entity.item_type = ItemData.ItemType.STONE
+	entity.count = 5
+	entity._pickup_ready = true
+	entity._merging = true
+	add_child(entity)
+
+	var inventory = Inventory.new()
+	var picked = entity.try_pickup(inventory)
+
+	assert_eq(picked, 0, "Should not pick up when merging")
+	entity.queue_free()
+
+
+# =============================================================================
+# Max Stack
+# =============================================================================
+
+func test_item_entity_get_max_stack():
+	var entity = ItemEntity.new()
+	entity.item_type = ItemData.ItemType.DIRT
+	assert_eq(entity.get_max_stack(), 64, "Dirt max stack should be 64")
+	entity.free()
+
+
+func test_item_entity_get_max_stack_tool():
+	var entity = ItemEntity.new()
+	entity.item_type = ItemData.ItemType.WOODEN_PICKAXE
+	assert_eq(entity.get_max_stack(), 1, "Tool max stack should be 1")
+	entity.free()
+
+
+# =============================================================================
+# Item Group
+# =============================================================================
+
+func test_item_entity_adds_to_group():
+	var entity = ItemEntity.new()
+	add_child(entity)
+	assert_true(entity.is_in_group("item_entities"), "Should be in 'item_entities' group")
+	entity.queue_free()
+
+
+# =============================================================================
+# Spawn Factory
+# =============================================================================
+
+func test_item_entity_spawn_creates_entity():
+	var parent = Node2D.new()
+	add_child(parent)
+
+	var entity = ItemEntity.spawn(parent, ItemData.ItemType.COAL, 3, Vector2(100, -50))
+
+	assert_not_null(entity, "spawn should return non-null entity")
+	assert_eq(entity.item_type, ItemData.ItemType.COAL, "Spawned entity item_type should match")
+	assert_eq(entity.count, 3, "Spawned entity count should match")
+	assert_eq(entity.position, Vector2(100, -50), "Spawned entity position should match")
+	assert_true(entity.is_inside_tree(), "Spawned entity should be in the scene tree")
+
+	parent.queue_free()
+
+
+func test_item_entity_spawn_adds_to_parent():
+	var parent = Node2D.new()
+	add_child(parent)
+
+	ItemEntity.spawn(parent, ItemData.ItemType.SAND, 1, Vector2.ZERO)
+
+	var children = parent.get_children()
+	assert_gt(children.size(), 0, "Parent should have child after spawn")
+
+	parent.queue_free()
+
+
+# =============================================================================
+# Merging
+# =============================================================================
+
+func test_item_entity_merge_same_type():
+	var parent = Node2D.new()
+	add_child(parent)
+
+	var entity1 = ItemEntity.new()
+	entity1.item_type = ItemData.ItemType.STONE
+	entity1.count = 10
+	entity1.position = Vector2(100, 100)
+	entity1._base_y = 100
+	parent.add_child(entity1)
+
+	var entity2 = ItemEntity.new()
+	entity2.item_type = ItemData.ItemType.STONE
+	entity2.count = 5
+	entity2.position = Vector2(110, 100) # Within MERGE_RADIUS (24px)
+	entity2._base_y = 100
+	parent.add_child(entity2)
+
+	# Trigger merge manually
+	entity1._try_merge_nearby()
+
+	assert_eq(entity1.count, 15, "Entity1 should have merged count of 15")
+	assert_true(entity2._merging, "Entity2 should be marked as merging (will be freed)")
+
+	parent.queue_free()
+
+
+func test_item_entity_no_merge_different_type():
+	var parent = Node2D.new()
+	add_child(parent)
+
+	var entity1 = ItemEntity.new()
+	entity1.item_type = ItemData.ItemType.STONE
+	entity1.count = 10
+	entity1.position = Vector2(100, 100)
+	entity1._base_y = 100
+	parent.add_child(entity1)
+
+	var entity2 = ItemEntity.new()
+	entity2.item_type = ItemData.ItemType.DIRT
+	entity2.count = 5
+	entity2.position = Vector2(110, 100)
+	entity2._base_y = 100
+	parent.add_child(entity2)
+
+	entity1._try_merge_nearby()
+
+	assert_eq(entity1.count, 10, "Entity1 should not merge with different type")
+	assert_eq(entity2.count, 5, "Entity2 should not be merged")
+
+	parent.queue_free()
+
+
+func test_item_entity_no_merge_too_far():
+	var parent = Node2D.new()
+	add_child(parent)
+
+	var entity1 = ItemEntity.new()
+	entity1.item_type = ItemData.ItemType.STONE
+	entity1.count = 10
+	entity1.position = Vector2(100, 100)
+	entity1._base_y = 100
+	parent.add_child(entity1)
+
+	var entity2 = ItemEntity.new()
+	entity2.item_type = ItemData.ItemType.STONE
+	entity2.count = 5
+	entity2.position = Vector2(200, 100) # Beyond MERGE_RADIUS (24px)
+	entity2._base_y = 100
+	parent.add_child(entity2)
+
+	entity1._try_merge_nearby()
+
+	assert_eq(entity1.count, 10, "Entity1 should not merge with faraway entity")
+	assert_eq(entity2.count, 5, "Entity2 should not be merged")
+
+	parent.queue_free()
+
+
+func test_item_entity_merge_respects_max_stack():
+	var parent = Node2D.new()
+	add_child(parent)
+
+	var entity1 = ItemEntity.new()
+	entity1.item_type = ItemData.ItemType.STONE
+	entity1.count = 60
+	entity1.position = Vector2(100, 100)
+	entity1._base_y = 100
+	parent.add_child(entity1)
+
+	var entity2 = ItemEntity.new()
+	entity2.item_type = ItemData.ItemType.STONE
+	entity2.count = 10
+	entity2.position = Vector2(110, 100)
+	entity2._base_y = 100
+	parent.add_child(entity2)
+
+	entity1._try_merge_nearby()
+
+	# Max stack is 64, so entity1 can only absorb 4 more
+	assert_eq(entity1.count, 64, "Entity1 should be capped at max stack")
+	assert_eq(entity2.count, 6, "Entity2 should have remaining items")
+	assert_false(entity2._merging, "Entity2 should not be freed (still has items)")
+
+	parent.queue_free()
+
+
+func test_item_entity_no_merge_on_belt():
+	var parent = Node2D.new()
+	add_child(parent)
+
+	var entity1 = ItemEntity.new()
+	entity1.item_type = ItemData.ItemType.STONE
+	entity1.count = 10
+	entity1.position = Vector2(100, 100)
+	entity1._base_y = 100
+	entity1.on_belt = true
+	parent.add_child(entity1)
+
+	var entity2 = ItemEntity.new()
+	entity2.item_type = ItemData.ItemType.STONE
+	entity2.count = 5
+	entity2.position = Vector2(110, 100)
+	entity2._base_y = 100
+	parent.add_child(entity2)
+
+	entity1._try_merge_nearby()
+
+	assert_eq(entity1.count, 10, "Belt items should not merge")
+
+	parent.queue_free()
+
+
+func test_item_entity_merge_emits_signal():
+	var parent = Node2D.new()
+	add_child(parent)
+
+	var entity1 = ItemEntity.new()
+	entity1.item_type = ItemData.ItemType.STONE
+	entity1.count = 10
+	entity1.position = Vector2(100, 100)
+	entity1._base_y = 100
+	parent.add_child(entity1)
+
+	var entity2 = ItemEntity.new()
+	entity2.item_type = ItemData.ItemType.STONE
+	entity2.count = 5
+	entity2.position = Vector2(110, 100)
+	entity2._base_y = 100
+	parent.add_child(entity2)
+
+	watch_signals(entity1)
+	entity1._try_merge_nearby()
+
+	assert_signal_emitted(entity1, "merged", "Should emit merged signal")
+
+	parent.queue_free()
+
+
+# =============================================================================
+# EntitySaver Integration
+# =============================================================================
+
+func test_entity_saver_serializes_item_entities():
+	var parent = Node2D.new()
+	add_child(parent)
+
+	var entity = ItemEntity.new()
+	entity.item_type = ItemData.ItemType.DIAMOND
+	entity.count = 2
+	entity.position = Vector2(50, -100)
+	entity._base_y = -100
+	parent.add_child(entity)
+
+	var all_data = EntitySaver.serialize_all(get_tree())
+
+	var found = false
+	for data in all_data:
+		if data.get("type") == "ItemEntity":
+			found = true
+			assert_eq(data["item_type"], ItemData.ItemType.DIAMOND, "Serialized item_type should match")
+			assert_eq(data["count"], 2, "Serialized count should match")
+
+	assert_true(found, "EntitySaver should serialize item entities")
+
+	parent.queue_free()
+
+
+func test_entity_saver_skips_belt_items():
+	var parent = Node2D.new()
+	add_child(parent)
+
+	var entity = ItemEntity.new()
+	entity.item_type = ItemData.ItemType.COAL
+	entity.count = 1
+	entity.on_belt = true
+	parent.add_child(entity)
+
+	var all_data = EntitySaver.serialize_all(get_tree())
+
+	var found = false
+	for data in all_data:
+		if data.get("type") == "ItemEntity":
+			found = true
+
+	assert_false(found, "EntitySaver should skip items on belts")
+
+	parent.queue_free()

--- a/game/tests/unit/test_item_entity.gd.uid
+++ b/game/tests/unit/test_item_entity.gd.uid
@@ -1,0 +1,1 @@
+uid://0rr0bsng3hrs


### PR DESCRIPTION
## Summary

- Add `ItemEntity` (Area2D) scene and script for visual items that exist in the game world with colored placeholders, bobbing animation, count labels, and collision-based player pickup
- Integrate item overflow drops from miners and player mining when inventory is full
- Add belt system visuals: items spawn as `ItemEntity` children on belt entities, move with belt progress, and drop as world items at unconnected belt ends
- Implement item stacking/merging for same-type ground items within 24px, despawn timer (300s default), and save/load support via `EntitySaver`
- Add 30+ GUT unit tests covering the full item entity lifecycle

## Changes

### New files
- `game/scenes/entities/item_entity.tscn` — Scene: Area2D root, CircleShape2D collision, ColorRect sprite, count Label
- `game/scripts/entities/item_entity.gd` — Core class: pickup, merge, despawn, serialize/deserialize, static `spawn()` factory
- `game/tests/unit/test_item_entity.gd` — Unit tests for all ItemEntity functionality

### Modified files
- `game/scripts/entities/miner.gd` — `_complete_mining()` now spawns `ItemEntity` behind miner on inventory overflow
- `game/scripts/player/mining_controller.gd` — `try_mine_at()` spawns `ItemEntity` at block position on inventory overflow
- `game/scripts/systems/belt_system.gd` — Visual item management on belts, item drop signal, end-of-belt world drops
- `game/scripts/save/entity_saver.gd` — Serialize/deserialize `ItemEntity` (ground items only, belt items excluded)
- `game/scripts/main.gd` — Clear item entities on load via `_remove_all_item_entities()`

Closes #10