### PR TITLE
Fix miner inventory click-through to blocks

### DIFF
--- a/game/scenes/ui/hotbar.tscn
+++ b/game/scenes/ui/hotbar.tscn
@@ -5,4 +5,5 @@
 [node name="HotbarUI" type="Control"]
 layout_mode = 3
 anchors_preset = 0
+mouse_filter = 0
 script = ExtResource("1_script")

--- a/game/scenes/ui/inventory.tscn
+++ b/game/scenes/ui/inventory.tscn
@@ -5,4 +5,5 @@
 [node name="InventoryUI" type="Control"]
 layout_mode = 3
 anchors_preset = 0
+mouse_filter = 0
 script = ExtResource("1_script")

--- a/game/scenes/ui/miner_inventory.tscn
+++ b/game/scenes/ui/miner_inventory.tscn
@@ -5,4 +5,5 @@
 [node name="MinerInventoryUI" type="Control"]
 layout_mode = 3
 anchors_preset = 0
+mouse_filter = 0
 script = ExtResource("1_script")

--- a/game/scripts/player/input_manager.gd
+++ b/game/scripts/player/input_manager.gd
@@ -118,8 +118,8 @@ func _handle_actions() -> void:
 	if player_controller == null:
 		return
 
-	# Block mining/placing when inventory is open
-	if inventory_ui and inventory_ui.is_open():
+	# Block mining/placing when inventory or miner UI is open
+	if (inventory_ui and inventory_ui.is_open()) or (miner_inventory_ui and miner_inventory_ui.is_open()):
 		return
 
 	# simple click-to-interact

--- a/game/scripts/ui/hotbar_ui.gd
+++ b/game/scripts/ui/hotbar_ui.gd
@@ -51,6 +51,7 @@ func _create_slots() -> void:
 	for i in range(SLOT_COUNT):
 		var panel = Panel.new()
 		panel.custom_minimum_size = Vector2(SLOT_SIZE, SLOT_SIZE)
+		panel.mouse_filter = Control.MOUSE_FILTER_STOP
 		container.add_child(panel)
 		_slot_panels.append(panel)
 

--- a/game/scripts/ui/inventory_ui.gd
+++ b/game/scripts/ui/inventory_ui.gd
@@ -66,6 +66,7 @@ func _create_grid() -> void:
 	# Create centered panel background
 	var background = Panel.new()
 	background.name = "Background"
+	background.mouse_filter = Control.MOUSE_FILTER_STOP
 	add_child(background)
 
 	# Create grid container

--- a/game/scripts/ui/miner_inventory_ui.gd
+++ b/game/scripts/ui/miner_inventory_ui.gd
@@ -255,7 +255,7 @@ func _create_panel() -> void:
 
 	# --- Measurements ---
 	var grid_cols = COLUMNS
-	var slot_count = Miner.MINER_INVENTORY_SIZE  # 18
+	var slot_count = Miner.MINER_INVENTORY_SIZE # 18
 	var grid_rows = int(ceil(float(slot_count) / grid_cols))
 	var grid_width = grid_cols * SLOT_SIZE + (grid_cols - 1) * SLOT_MARGIN
 	var grid_height = grid_rows * SLOT_SIZE + (grid_rows - 1) * SLOT_MARGIN
@@ -265,6 +265,7 @@ func _create_panel() -> void:
 	# --- Background panel ---
 	var background = Panel.new()
 	background.name = "Background"
+	background.mouse_filter = Control.MOUSE_FILTER_STOP
 	background.custom_minimum_size = Vector2(panel_width, panel_height)
 	add_child(background)
 


### PR DESCRIPTION
Closes #21. This PR prevents mouse clicks on UI elements from passing through to the world, which was causing unintended mining and placement.

Key changes:
- Set 'Mouse Filter' to 'Stop' on UI background panels in scripts and scenes.
- Updated 'InputManager' to block game actions when the miner inventory UI is open.
- Applied fixes to 'HotbarUI', 'InventoryUI', and 'MinerInventoryUI' for consistency.